### PR TITLE
Set currentPlayerHash if a user join as player1

### DIFF
--- a/src/Controller/GameController.php
+++ b/src/Controller/GameController.php
@@ -95,6 +95,7 @@ class GameController extends AbstractController
                 // If this game has no player 1 (this case is impossible in theory but for debugging purpose it's useful)
                 // Set this player as player 1
                 $game->setPlayer1Hash($playerHash);
+                $game->setCurrentPlayerHash($playerHash);
             } elseif ($playerHash !== $game->getPlayer1Hash() && $game->getPlayer2Hash() === null) {
                 // If game has no player 2
                 // Start this game !


### PR DESCRIPTION
I have added a tweak to be able to join a game as player 1 for the demo.
But when I do this, currentPlayer is not set and nobody can play, this PR fix this case.

- [x] setCurrentPlayer as player1 on join route