### PR TITLE
Allow control origin * for API calls

### DIFF
--- a/.env
+++ b/.env
@@ -29,5 +29,5 @@ APP_SECRET=ea92ba9f5d776bb49c40d8ddb959703c
 
 
 ###> nelmio/cors-bundle ###
-CORS_ALLOW_ORIGIN='^http://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
+CORS_ALLOW_ORIGIN='*'
 ###< nelmio/cors-bundle ###


### PR DESCRIPTION
Localhost is not known from EC2 server.
So we need to open the control origin to * for accessing from everywhere.

- [x] Update env var `CORS_ALLOW_ORIGIN='*'`