### PR TITLE
Add route to play against computer

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -12,9 +12,3 @@ services:
     depends_on:
       - symfony
 
-  go:
-    image: alpine
-    volumes:
-      - "./go:/app"
-    working_dir: /app
-    command: "./main"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,5 +32,12 @@ services:
     ports:
       - 8082:80
       - 443:433
+  
+  go:
+    image: alpine
+    volumes:
+      - "./go:/app"
+    working_dir: /app
+    command: "./main"
 volumes:
   database-data:

--- a/migrations/Version20210218152002.php
+++ b/migrations/Version20210218152002.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20210218152002 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE game ADD against_computer BOOLEAN DEFAULT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('ALTER TABLE game DROP against_computer');
+    }
+}

--- a/src/Controller/GameController.php
+++ b/src/Controller/GameController.php
@@ -69,8 +69,9 @@ class GameController extends AbstractController
         $playerRepository = $this->getDoctrine()->getRepository(Player::class);
         $player = $playerRepository->find($playerId);
 
-        
-        $game = $this->gameService->initGame($player);
+        $againstComputer = $content["againstComputer"];
+
+        $game = $this->gameService->initGame($player, $againstComputer);
         
         $entityManager = $this->getDoctrine()->getManager();
         $entityManager->persist($game);
@@ -120,11 +121,6 @@ class GameController extends AbstractController
             }
             $entityManager->flush();
         }
-        // $this->notify(
-        //     $publisher,
-        //     $game->getId(),
-        //     ["status" => "join", "value" => null]
-        // );
 
         $response = JsonResponse::fromJsonString(
             $this->serializer->serialize($game, 'json'),
@@ -205,16 +201,6 @@ class GameController extends AbstractController
 
         $game = $this->gameService->addMarbleIfPositionIsValid($game, $position);
         $entityManager->flush();
-        $currentPlayerValue = $this->gameService->getCurrentPlayerValue($game);
-
-        // $this->notify(
-        //     $publisher,
-        //     $game->getId(),
-        //     [
-        //         "status" => $this->gameService::ADD_MARBLE_STATUS,
-        //         "value" => ["position" => $position, "playerValue" => $currentPlayerValue],
-        //     ]
-        // );
 
         return JsonResponse::fromJsonString(
             $this->serializer->serialize($game, 'json'),
@@ -256,15 +242,6 @@ class GameController extends AbstractController
         $game = $this->gameService->rotateQuarterBy90Degrees($game, $rotation);
 
         $entityManager->flush();
-
-        // $this->notify(
-        //     $publisher,
-        //     $game->getId(),
-        //     [
-        //         "status" => $this->gameService::ROTATE_QUARTER_STATUS,
-        //         "value" => $rotation,
-        //     ]
-        // );
 
         return JsonResponse::fromJsonString(
             $this->serializer->serialize($game, 'json'),

--- a/src/Controller/IAController.php
+++ b/src/Controller/IAController.php
@@ -11,6 +11,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Normalizer\UidNormalizer;
 use Symfony\Component\Serializer\Serializer;
 
 use App\Entity\Game;
@@ -27,7 +28,7 @@ class IAController extends AbstractController
         $this->gameService = $gameService;
         $this->client = $client;
         $encoders = [new JsonEncoder()];
-        $normalizers = [new ObjectNormalizer()];
+        $normalizers = [new UidNormalizer(), new ObjectNormalizer()];
 
         $this->serializer = new Serializer($normalizers, $encoders);
     }
@@ -69,6 +70,52 @@ class IAController extends AbstractController
              $this->serializer->serialize($content, 'json'),
              JsonResponse::HTTP_OK
          );
+        return $response;
+    }
+
+    /**
+     * @Route("/games/{id}/computer/play", name="game_computer_play", methods={"POST"})
+     */
+    public function getComputerPlay(string $id): JsonResponse
+    {
+        
+        $entityManager = $this->getDoctrine()->getManager();
+        $game = $entityManager->getRepository(Game::class)->find($id);
+
+        if (!$game) {
+            return new JsonResponse("Game not found", JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $advice = $this->client->request(
+            'POST',
+            $this->getParameter('app.ai_url'),
+            [
+                'json' => [
+                    'board' => $game->getBoard(),
+                    'currentPlayer' => 2
+                ]
+            ]
+        );
+        $statusCode = $advice->getStatusCode();
+
+        if ($statusCode > 399) {
+            return new JsonResponse("Advice service not available", $statusCode);
+        }
+        // casts the response JSON content to a PHP array
+        $content = $advice->toArray();
+        $position = $content["PlaceMarble"];
+        $game = $this->gameService->addMarbleIfPositionIsValid($game, $position);
+
+        $rotationKey = $this->gameService->getRotationKeyFromIA($content["Rotate"]);
+
+        $game = $this->gameService->rotateQuarterBy90Degrees($game, $rotationKey);
+        $game->setCurrentPlayer($game->getPlayer1());
+        $entityManager->flush();
+
+        $response = JsonResponse::fromJsonString(
+            $this->serializer->serialize($game, 'json'),
+            JsonResponse::HTTP_OK
+        );
         return $response;
     }
 }

--- a/src/Entity/Game.php
+++ b/src/Entity/Game.php
@@ -69,6 +69,11 @@ class Game
      */
     private $created;
 
+    /**
+     * @ORM\Column(type="boolean", nullable=true)
+     */
+    private $againstComputer;
+
     public function getId(): ?UuidV4
     {
         return $this->id;
@@ -173,5 +178,17 @@ class Game
     public function getCreated(): ?DateTime
     {
         return $this->created;
+    }
+
+    public function getAgainstComputer(): ?bool
+    {
+        return $this->againstComputer;
+    }
+
+    public function setAgainstComputer(?bool $againstComputer): self
+    {
+        $this->againstComputer = $againstComputer;
+
+        return $this;
     }
 }

--- a/src/Service/GameService.php
+++ b/src/Service/GameService.php
@@ -24,13 +24,21 @@ class GameService
         $this->winDetectionService = $winDetectionService;
     }
 
-    public function initGame(Player $player): Game
+    public function initGame(Player $player, $againstComputer): Game
     {
         $game = new Game();
         $game->setBoard($this->boardService->initBoard());
         $game->setTurnStatus(self::ADD_MARBLE_STATUS);
-        $game->setStatus(self::GAME_WAITING_OPPONENT);
         $game->setPlayer1($player);
+        $game->setAgainstComputer($againstComputer);
+
+        if (!$againstComputer) {
+            $game->setStatus(self::GAME_WAITING_OPPONENT);
+        } else {
+            $game->setCurrentPlayer($game->getPlayer1());
+            $game->setStatus(self::GAME_STARTED);
+        }
+        
 
         return $game;
     }
@@ -61,7 +69,7 @@ class GameService
             return 1;
         }
 
-        if ($game->getPlayer2() === $game->getCurrentPlayer()) {
+        if (!$game->getCurrentPlayer() || $game->getPlayer2() === $game->getCurrentPlayer()) {
             return 2;
         }
 
@@ -69,8 +77,12 @@ class GameService
     }
 
     // End of turn, switch to the other player.
-    public function changeCurrentPlayer(Game $game): Player
+    public function changeCurrentPlayer(Game $game): ?Player
     {
+        if ($game->getAgainstComputer()) {
+            return $game->getCurrentPlayer() === $game->getPlayer1() ? NULL : $game->getPlayer1();
+        }
+
         return $game->getCurrentPlayer() === $game->getPlayer1() ? $game->getPlayer2() : $game->getPlayer1();
     }
 
@@ -171,5 +183,20 @@ class GameService
         }
 
         return $game;
+    }
+
+    public function getRotationKeyFromIA($rotation): int {
+        switch(intval($rotation[0])) {
+            case 1:
+            default:
+                return $rotation[1] === "counter-clockwise" ? 0 : 1;
+            case 2:
+                return $rotation[1] === "counter-clockwise" ? 2 : 3;
+            case 3:
+                return $rotation[1] === "counter-clockwise" ? 4 : 5;
+            case 4:
+                return $rotation[1] === "counter-clockwise" ? 6 : 7;
+                
+        }
     }
 }

--- a/src/Service/GameService.php
+++ b/src/Service/GameService.php
@@ -80,7 +80,7 @@ class GameService
     public function changeCurrentPlayer(Game $game): ?Player
     {
         if ($game->getAgainstComputer()) {
-            return $game->getCurrentPlayer() === $game->getPlayer1() ? NULL : $game->getPlayer1();
+            return $game->getCurrentPlayer() === $game->getPlayer1() ? null : $game->getPlayer1();
         }
 
         return $game->getCurrentPlayer() === $game->getPlayer1() ? $game->getPlayer2() : $game->getPlayer1();
@@ -185,8 +185,9 @@ class GameService
         return $game;
     }
 
-    public function getRotationKeyFromIA($rotation): int {
-        switch(intval($rotation[0])) {
+    public function getRotationKeyFromIA($rotation): int
+    {
+        switch (intval($rotation[0])) {
             case 1:
             default:
                 return $rotation[1] === "counter-clockwise" ? 0 : 1;
@@ -196,7 +197,6 @@ class GameService
                 return $rotation[1] === "counter-clockwise" ? 4 : 5;
             case 4:
                 return $rotation[1] === "counter-clockwise" ? 6 : 7;
-                
         }
     }
 }


### PR DESCRIPTION
- [x] go service is now global for both dev & prod env
- [x] Add `againstComputer` bool. If currentPlayer if null, it means that it's the computer's turn. (very poor idea but... fast)

- [x] Add a route to launch a computer play.

To give a chance to the player 1, we will always start.

![computer](https://user-images.githubusercontent.com/12797391/108384831-63d45a80-720b-11eb-8e60-e4daf01bac92.gif)
